### PR TITLE
Motion Icon Location & Scale Customization

### DIFF
--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -59,6 +59,9 @@ namespace Razgriz.RATS
         public bool StateBlendtreeLabels = true;
         public bool StateAnimIsEmptyLabel = true;
         public bool StateLoopedLabels = true;
+        public float StateGraphIconScale = 1.0f;
+        public float StateMotionIconOffset = 5.0f;
+        public bool StateGraphIconLocation = false;
         public Color StateExtraLabelsColorEnabled = new Color(1.0f, 1.0f, 1.0f, 0.8f);
         public Color StateExtraLabelsColorDisabled = new Color(1.0f, 1.0f, 1.0f, 0.05f);
         public bool ShowWarningsTopLeft = true;
@@ -322,6 +325,13 @@ namespace Razgriz.RATS
                     ToggleButton(ref RATS.Prefs.StateAnimIsEmptyLabel, new GUIContent("   Empty Anims/States", EditorGUIUtility.IconContent("Warning").image, "Display a warning if a state's animation is empty or if a state has no motion"));
                 }
                 RATS.Prefs.ShowWarningsTopLeft = BooleanDropdown(RATS.Prefs.ShowWarningsTopLeft, "Warning Location", "Next To Motion Name", "Top Left");
+
+                using (new GUILayout.HorizontalScope())
+                {
+                    RATS.Prefs.StateGraphIconScale = EditorGUILayout.Slider("Icon Scale", RATS.Prefs.StateGraphIconScale, 1.0f, 1.5f);
+                    RATS.Prefs.StateMotionIconOffset = EditorGUILayout.Slider("Icon Offset", RATS.Prefs.StateMotionIconOffset, 0.0f, 20.0f);
+                }
+                RATS.Prefs.StateGraphIconLocation = BooleanDropdown(RATS.Prefs.StateGraphIconLocation, "Icon Location", "Left of Motion Name", "Left Corner");
 
                 EditorGUILayout.Space(8);
                 using (new GUILayout.HorizontalScope())

--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -58,6 +58,7 @@ namespace Razgriz.RATS
         public bool StateMotionLabels = true;
         public bool StateBlendtreeLabels = true;
         public bool StateAnimIsEmptyLabel = true;
+        public bool StateColoredAnimIcon = false; 
         public bool StateLoopedLabels = true;
         public float StateGraphIconScale = 1.0f;
         public float StateMotionIconOffset = 5.0f;
@@ -323,6 +324,7 @@ namespace Razgriz.RATS
                 using (new GUILayout.HorizontalScope())
                 {
                     ToggleButton(ref RATS.Prefs.StateAnimIsEmptyLabel, new GUIContent("   Empty Anims/States", EditorGUIUtility.IconContent("Warning").image, "Display a warning if a state's animation is empty or if a state has no motion"));
+                    ToggleButton(ref RATS.Prefs.StateColoredAnimIcon, new GUIContent("   Colored Anim Icon", EditorGUIUtility.IconContent("d_AnimationClip Icon").image, "Should the Animation clip icon be monochrome or colored?"));
                 }
                 RATS.Prefs.ShowWarningsTopLeft = BooleanDropdown(RATS.Prefs.ShowWarningsTopLeft, "Warning Location", "Next To Motion Name", "Top Left");
 

--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -58,11 +58,10 @@ namespace Razgriz.RATS
         public bool StateMotionLabels = true;
         public bool StateBlendtreeLabels = true;
         public bool StateAnimIsEmptyLabel = true;
-        public bool StateColoredAnimIcon = false; 
+        public bool StateColoredAnimIcon = false;
         public bool StateLoopedLabels = true;
         public float StateGraphIconScale = 1.0f;
-        public float StateMotionIconOffset = 5.0f;
-        public bool StateGraphIconLocation = false;
+        public bool StateGraphIconLocationIsCorner = false;
         public Color StateExtraLabelsColorEnabled = new Color(1.0f, 1.0f, 1.0f, 0.8f);
         public Color StateExtraLabelsColorDisabled = new Color(1.0f, 1.0f, 1.0f, 0.05f);
         public bool ShowWarningsTopLeft = true;
@@ -326,14 +325,14 @@ namespace Razgriz.RATS
                     ToggleButton(ref RATS.Prefs.StateAnimIsEmptyLabel, new GUIContent("   Empty Anims/States", EditorGUIUtility.IconContent("Warning").image, "Display a warning if a state's animation is empty or if a state has no motion"));
                     ToggleButton(ref RATS.Prefs.StateColoredAnimIcon, new GUIContent("   Colored Anim Icon", EditorGUIUtility.IconContent("d_AnimationClip Icon").image, "Should the Animation clip icon be monochrome or colored?"));
                 }
-                RATS.Prefs.ShowWarningsTopLeft = BooleanDropdown(RATS.Prefs.ShowWarningsTopLeft, "Warning Location", "Next To Motion Name", "Top Left");
+                
+                RATS.Prefs.StateGraphIconScale = EditorGUILayout.Slider("Icon Scale", RATS.Prefs.StateGraphIconScale, 1.0f, 1.5f);
 
                 using (new GUILayout.HorizontalScope())
                 {
-                    RATS.Prefs.StateGraphIconScale = EditorGUILayout.Slider("Icon Scale", RATS.Prefs.StateGraphIconScale, 1.0f, 1.5f);
-                    RATS.Prefs.StateMotionIconOffset = EditorGUILayout.Slider("Icon Offset", RATS.Prefs.StateMotionIconOffset, 0.0f, 20.0f);
+                    RATS.Prefs.ShowWarningsTopLeft = BooleanDropdown(RATS.Prefs.ShowWarningsTopLeft, "Warning Location", "Next To Motion Name", "Top Left");
+                    RATS.Prefs.StateGraphIconLocationIsCorner = BooleanDropdown(RATS.Prefs.StateGraphIconLocationIsCorner, "Icon Location", "Next to Motion Name", "Left Corner");
                 }
-                RATS.Prefs.StateGraphIconLocation = BooleanDropdown(RATS.Prefs.StateGraphIconLocation, "Icon Location", "Left of Motion Name", "Left Corner");
 
                 EditorGUILayout.Space(8);
                 using (new GUILayout.HorizontalScope())

--- a/Editor/RATSPatchesAnimatorWindow.cs
+++ b/Editor/RATSPatchesAnimatorWindow.cs
@@ -766,15 +766,17 @@ namespace Razgriz.RATS
                     // Loop time label
                     if(isLoopTime && (debugShowLabels || RATS.Prefs.StateLoopedLabels))
                     {
-                        Rect loopingLabelRect = new Rect(stateRect.x + 1, stateRect.y - 29, 16, 16);
+                        float loopTimeIconSize = 16f * RATS.Prefs.StateGraphIconScale;
+                        Rect loopingLabelRect = new Rect(stateRect.x + 1, stateRect.y - 29, loopTimeIconSize, loopTimeIconSize);
                         EditorGUI.LabelField(loopingLabelRect, new GUIContent(EditorGUIUtility.IconContent("d_preAudioLoopOff@2x").image, "Animation Clip is Looping"));
-                        iconOffset += (14f *  RATS.Prefs.StateGraphIconScale);
+                        iconOffset += 14f * RATS.Prefs.StateGraphIconScale;
                     }
                     
                     // Empty Animation/State Warning, top left (option)
                     if(RATS.Prefs.ShowWarningsTopLeft)
                     {
-                        Rect emptyWarningRect = new Rect(stateRect.x + iconOffset + 1, stateRect.y - 28, 14, 14);
+                        float warningsIconSize = 14f * RATS.Prefs.StateGraphIconScale;
+                        Rect emptyWarningRect = new Rect(stateRect.x + iconOffset + 1, stateRect.y - 28, warningsIconSize, warningsIconSize);
                         if((debugShowLabels || RATS.Prefs.StateAnimIsEmptyLabel))
                         {
                             if(isEmptyAnim) EditorGUI.LabelField(emptyWarningRect, new GUIContent(EditorGUIUtility.IconContent("Warning@2x").image, "Animation Clip has no Keyframes"));
@@ -793,14 +795,13 @@ namespace Razgriz.RATS
                             // use the value of aState.motion.name if it's is not null, otherwise use a different value
                             string motionName = aState?.motion?.name ?? "[none]";
 
-                            float iconSize = (13f *  RATS.Prefs.StateGraphIconScale);
+                            float iconSize = 14f * RATS.Prefs.StateGraphIconScale;
 
                             GUIContent labelIconContent = new GUIContent();
                             if(hasblendtree)
                             {
                                 labelIconContent.image = EditorGUIUtility.IconContent("d_BlendTree Icon").image;
                                 labelIconContent.tooltip = "State contains a Blendtree";
-                                iconSize = (14f *  RATS.Prefs.StateGraphIconScale);
                             }
                             else if(isEmptyAnim && !RATS.Prefs.ShowWarningsTopLeft)
                             {
@@ -814,40 +815,25 @@ namespace Razgriz.RATS
                             }
                             else 
                             {
-                                if(RATS.Prefs.StateColoredAnimIcon)
-                                {
-                                    labelIconContent.image = EditorGUIUtility.IconContent("d_AnimationClip Icon").image;  
-                                }
-                                else
-                                {
-                                    labelIconContent.image = EditorGUIUtility.IconContent("AnimationClip On Icon").image;
-                                }
-                    
+                                string animationClipIconName = RATS.Prefs.StateColoredAnimIcon ? "d_AnimationClip Icon" : "AnimationClip On Icon";
+                                labelIconContent.image = EditorGUIUtility.IconContent(animationClipIconName).image;
                                 labelIconContent.tooltip = "State contains an Animation Clip";
-                                iconSize = (16f *  RATS.Prefs.StateGraphIconScale);
                             }
 
                             GUIContent motionLabel = new GUIContent(motionName);
-                            float width = EditorStyles.label.CalcSize(motionLabel).x;
-                            float height = EditorStyles.label.CalcSize(motionLabel).y;
+                            Vector2 motionLabelSize = StateMotionStyle.CalcSize(motionLabel);
 
-                            Rect motionLabelRect = new Rect(stateRect.x + stateRect.width/2 - width/2, stateRect.y - height/2, width, height);
+                            Rect motionLabelRect = new Rect(stateRect.x + stateRect.width/2 - motionLabelSize.x/2, stateRect.y - motionLabelSize.y/2, motionLabelSize.x, motionLabelSize.y);
+                            motionLabelRect.x = Mathf.Clamp(motionLabelRect.x, iconSize, stateRect.width/2);
 
-                            float _MotionIconOffsetX = 0.0f;
-                            float _MotionIconOffsetY = 0.0f;
+                            Vector2 motionIconOffset = new Vector2(0f, 1f + motionLabelRect.y - iconSize/2f + motionLabelRect.height/2f);
 
-                            if(RATS.Prefs.StateGraphIconLocation)
-                            {
-                                _MotionIconOffsetX = -0.25f + iconSize/8f + RATS.Prefs.StateMotionIconOffset;
-                                _MotionIconOffsetY = motionLabelRect.y + height/1.35f - iconSize/1.4f;
-                            } 
+                            if(RATS.Prefs.StateGraphIconLocationIsCorner)
+                                motionIconOffset.x += -1f + iconSize/8f;
                             else
-                            {
-                                _MotionIconOffsetX = Mathf.Clamp(((motionLabelRect.x - iconSize/2) - RATS.Prefs.StateMotionIconOffset),-0.5f, 250.0f);
-                                _MotionIconOffsetY = motionLabelRect.y + height/2 - iconSize/2;
-                            }
+                                motionIconOffset.x += -7f + (motionLabelRect.x - iconSize/2f);
 
-                            Rect motionIconRect = new Rect(_MotionIconOffsetX, _MotionIconOffsetY, iconSize, iconSize);
+                            Rect motionIconRect = new Rect(motionIconOffset.x, motionIconOffset.y, iconSize, iconSize);
 
                             EditorGUI.LabelField(motionLabelRect, motionLabel, StateMotionStyle);
                             EditorGUI.LabelField(motionIconRect, labelIconContent);

--- a/Editor/RATSPatchesAnimatorWindow.cs
+++ b/Editor/RATSPatchesAnimatorWindow.cs
@@ -814,7 +814,15 @@ namespace Razgriz.RATS
                             }
                             else 
                             {
-                                labelIconContent.image = EditorGUIUtility.IconContent("AnimationClip On Icon").image;
+                                if(RATS.Prefs.StateColoredAnimIcon)
+                                {
+                                    labelIconContent.image = EditorGUIUtility.IconContent("d_AnimationClip Icon").image;  
+                                }
+                                else
+                                {
+                                    labelIconContent.image = EditorGUIUtility.IconContent("AnimationClip On Icon").image;
+                                }
+                    
                                 labelIconContent.tooltip = "State contains an Animation Clip";
                                 iconSize = (16f *  RATS.Prefs.StateGraphIconScale);
                             }

--- a/Editor/RATSPatchesAnimatorWindow.cs
+++ b/Editor/RATSPatchesAnimatorWindow.cs
@@ -761,14 +761,14 @@ namespace Razgriz.RATS
                         if (aStateMachine.behaviours != null) hasBehavior = aStateMachine.behaviours.Length > 0;
                     }
 
-                    int iconOffset = 0;
+                    float iconOffset = 0;
 
                     // Loop time label
                     if(isLoopTime && (debugShowLabels || RATS.Prefs.StateLoopedLabels))
                     {
                         Rect loopingLabelRect = new Rect(stateRect.x + 1, stateRect.y - 29, 16, 16);
                         EditorGUI.LabelField(loopingLabelRect, new GUIContent(EditorGUIUtility.IconContent("d_preAudioLoopOff@2x").image, "Animation Clip is Looping"));
-                        iconOffset += 14;
+                        iconOffset += (14f *  RATS.Prefs.StateGraphIconScale);
                     }
                     
                     // Empty Animation/State Warning, top left (option)
@@ -793,14 +793,14 @@ namespace Razgriz.RATS
                             // use the value of aState.motion.name if it's is not null, otherwise use a different value
                             string motionName = aState?.motion?.name ?? "[none]";
 
-                            float iconSize = 13f;
+                            float iconSize = (13f *  RATS.Prefs.StateGraphIconScale);
 
                             GUIContent labelIconContent = new GUIContent();
                             if(hasblendtree)
                             {
                                 labelIconContent.image = EditorGUIUtility.IconContent("d_BlendTree Icon").image;
                                 labelIconContent.tooltip = "State contains a Blendtree";
-                                iconSize = 14;
+                                iconSize = (14f *  RATS.Prefs.StateGraphIconScale);
                             }
                             else if(isEmptyAnim && !RATS.Prefs.ShowWarningsTopLeft)
                             {
@@ -816,7 +816,7 @@ namespace Razgriz.RATS
                             {
                                 labelIconContent.image = EditorGUIUtility.IconContent("AnimationClip On Icon").image;
                                 labelIconContent.tooltip = "State contains an Animation Clip";
-                                iconSize = 16;
+                                iconSize = (16f *  RATS.Prefs.StateGraphIconScale);
                             }
 
                             GUIContent motionLabel = new GUIContent(motionName);
@@ -824,7 +824,22 @@ namespace Razgriz.RATS
                             float height = EditorStyles.label.CalcSize(motionLabel).y;
 
                             Rect motionLabelRect = new Rect(stateRect.x + stateRect.width/2 - width/2, stateRect.y - height/2, width, height);
-                            Rect motionIconRect = new Rect(motionLabelRect.x - iconSize/2 - 0.5f, motionLabelRect.y + height/2 - iconSize/2, iconSize, iconSize);
+
+                            float _MotionIconOffsetX = 0.0f;
+                            float _MotionIconOffsetY = 0.0f;
+
+                            if(RATS.Prefs.StateGraphIconLocation)
+                            {
+                                _MotionIconOffsetX = -0.25f + iconSize/8f + RATS.Prefs.StateMotionIconOffset;
+                                _MotionIconOffsetY = motionLabelRect.y + height/1.35f - iconSize/1.4f;
+                            } 
+                            else
+                            {
+                                _MotionIconOffsetX = Mathf.Clamp(((motionLabelRect.x - iconSize/2) - RATS.Prefs.StateMotionIconOffset),-0.5f, 250.0f);
+                                _MotionIconOffsetY = motionLabelRect.y + height/2 - iconSize/2;
+                            }
+
+                            Rect motionIconRect = new Rect(_MotionIconOffsetX, _MotionIconOffsetY, iconSize, iconSize);
 
                             EditorGUI.LabelField(motionLabelRect, motionLabel, StateMotionStyle);
                             EditorGUI.LabelField(motionIconRect, labelIconContent);


### PR DESCRIPTION
Added new controls for the state motion icons.
![image](https://user-images.githubusercontent.com/88603991/229372616-61d50fa0-eeca-488a-b64b-de57106ebbef.png)

- Colored Anim Icon (Bool)
- Icon Scale (Float, 1.0 - 1.5)
- Icon Offset (Float, 0.0 - 20.0)
- Icon Location (Bool, Left of Motion Name | Left Corner)

Left Corner Location Example
![image](https://user-images.githubusercontent.com/88603991/229371535-2e6bc52d-ace4-4af3-ab2b-2fc33e7af796.png)
