### PR TITLE
add Harmony as a VPM dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "name": "Raz"
   },
   "gitDependencies": {},
-  "vpmDependencies": {},
+  "vpmDependencies": {
+    "one.razgriz.harmony-vpm": "2.2.2"
+  },
   "legacyFolders": {},
   "legacyFiles": {},
   "hideInEditor": false,


### PR DESCRIPTION
When a user adds this package they no longer have to manually add Harmony.

I have a simple example with this here: https://konsti219.github.io/TestPackage-vpm/