### PR TITLE
Set defines on active build target instead of always Standalone

### DIFF
--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -650,19 +650,19 @@ namespace Razgriz.RATS
         {
             try
             {
-                string symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(
-                        BuildTargetGroup.Standalone);
+                BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget);
+                string symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
                 if (!symbols.Contains(symbol) && active)
                 {
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(
-                                BuildTargetGroup.Standalone, symbols + ";" + symbol);
+                                buildTargetGroup, symbols + ";" + symbol);
                     if(refresh_if_changed)
                         AssetDatabase.Refresh();
                 }
                 else if (symbols.Contains(symbol) && !active)
                 {
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(
-                                BuildTargetGroup.Standalone, Regex.Replace(symbols, @";?" + @symbol, ""));
+                                buildTargetGroup, Regex.Replace(symbols, @";?" + @symbol, ""));
                     if(refresh_if_changed)
                         AssetDatabase.Refresh();
                 }


### PR DESCRIPTION
RATSGUI.SetDefineSymbol() always sets defines on the Standalone build target group rather than the active build target group.
This change gets and uses the active group instead.

Fixes #22 (Android target)