### PR TITLE
Add Controller Cleanup, State/Transition Creation, and Transition Manipulation

### DIFF
--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -97,6 +97,8 @@ namespace Razgriz.RATS
         public bool DefaultTransitionOrderedInterruption = true;
         public bool DefaultTransitionCanTransitionToSelf = true;
         public bool ManipulateTransitionsMenuOption = true;
+        public bool DoubleClickObjectCreation = true;
+        public float DoubleClickTimeInterval = 0.15f;
         public bool LayerListShowWD = true;
         public bool LayerListShowMixedWD = true;
         public bool ParameterListShowParameterTypeLabels = true;
@@ -399,8 +401,13 @@ namespace Razgriz.RATS
                 using (new GUILayout.HorizontalScope())
                 {
                     ToggleButton(ref RATS.Prefs.ManipulateTransitionsMenuOption, "Add Transition Manipulation Right-Click Options", "Add options to right-click menu of States and Transitions");
+                    ToggleButton(ref RATS.Prefs.DoubleClickObjectCreation, "Double Click Object Creation", "Double Click on a state while holding left Control to create a Transition, double click elsewhere to create a State");
                 }
 
+                if (RATS.Prefs.DoubleClickObjectCreation)
+                {
+                    RATS.Prefs.DoubleClickTimeInterval = EditorGUILayout.Slider("Click Interval", RATS.Prefs.DoubleClickTimeInterval, 0.0f, 1.0f);
+                }
 
                 EditorGUI.indentLevel -= optionsIndentStep;
             }

--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -96,6 +96,7 @@ namespace Razgriz.RATS
         public int DefaultTransitionInterruptionSource = 0;
         public bool DefaultTransitionOrderedInterruption = true;
         public bool DefaultTransitionCanTransitionToSelf = true;
+        public bool ManipulateTransitionsMenuOption = true;
         public bool LayerListShowWD = true;
         public bool LayerListShowMixedWD = true;
         public bool ParameterListShowParameterTypeLabels = true;
@@ -212,6 +213,7 @@ namespace Razgriz.RATS
                     EditorGUI.indentLevel += 1;
                     DrawNodeSnappingOptions();
                     DrawGraphStateDefaultsOptions();
+                    DrawStateMachinePatchOptions();
                     DrawCompatibilityOptions();
                     EditorGUI.indentLevel -= 1;
                 }
@@ -380,6 +382,25 @@ namespace Razgriz.RATS
                     ToggleButton(ref RATS.Prefs.ParameterListShowParameterTypeLabels, "Show Parameter Type Labels", "Show the type of parameter being animated next to its value");
                     ToggleButton(ref RATS.Prefs.ParameterListShowParameterTypeLabelShorten, "Shorten Label", "Shorten the label to just the first letter");
                 }
+
+                EditorGUI.indentLevel -= optionsIndentStep;
+            }
+        }
+
+        private static void DrawStateMachinePatchOptions()
+        {
+            // State Machine
+            using (new GUILayout.VerticalScope())
+            {
+                DrawUILine(lightUILineColor);
+                SectionLabel(new GUIContent("  StateMachine Patches", EditorGUIUtility.IconContent("d_AnimatorStateMachine Icon").image));
+                EditorGUI.indentLevel += optionsIndentStep;
+
+                using (new GUILayout.HorizontalScope())
+                {
+                    ToggleButton(ref RATS.Prefs.ManipulateTransitionsMenuOption, "Add Transition Manipulation Right-Click Options", "Add options to right-click menu of States and Transitions");
+                }
+
 
                 EditorGUI.indentLevel -= optionsIndentStep;
             }

--- a/Editor/RATSPatchesAnimatorWindow.cs
+++ b/Editor/RATSPatchesAnimatorWindow.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
@@ -39,8 +40,16 @@ namespace Razgriz.RATS
             internal static Dictionary<string, bool> nodeBackgroundPatched = new Dictionary<string, bool>();
 
             // Layer copy/paste
-           internal static AnimatorControllerLayer layerClipboard = null;
-           internal static AnimatorController controllerClipboard = null;
+            internal static AnimatorControllerLayer layerClipboard = null;
+            internal static AnimatorController controllerClipboard = null;
+
+            // Transition Menu
+            internal static AnimatorTransitionBase redirectTransition;
+            internal static AnimatorTransitionBase replicateTransition;
+
+            // State Menu
+            internal static AnimatorState multipleState;
+
         }
 
 #if !RATS_NO_ANIMATOR // Compatibility
@@ -410,6 +419,403 @@ namespace Razgriz.RATS
             static void Prefix(ref AnimatorState state, Vector3 position)
             {
                 if(!RATS.Prefs.DefaultStateWriteDefaults) state.writeDefaultValues = false;
+            }
+        }
+
+        [HarmonyPatch]
+        [HarmonyPriority(Priority.Low)]
+        class PatchStateMenu
+        {
+            [HarmonyTargetMethod]
+            static MethodBase[] TargetMethods() => new[]
+            { 
+                AccessTools.Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.StateMachineNode"), "NodeUI"),
+                AccessTools.Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.StateNode"), "NodeUI"),
+                AccessTools.Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.AnyStateNode"), "NodeUI"),
+                AccessTools.Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.EntryNode"), "NodeUI"),
+            };
+
+            private static StateMenuEntry[] Entries = {
+                new MultipleTransitionEntry(),
+                new RedirectMenuEntry(),
+                new ReplicateMenuEntry()
+            };
+            
+            static void AddMenuItems(object graph, GenericMenu menu)
+            {
+                if (!RATS.Prefs.ManipulateTransitionsMenuOption) return;
+                if (Entries.Any(x => x.ShouldShow(graph))) menu.AddSeparator("");
+                
+                foreach (var entry in Entries)
+                {
+                    if (!entry.ShouldShow(graph)) continue;
+                    if (entry.ShouldEnable(graph))
+                    {
+                        menu.AddItem(EditorGUIUtility.TrTextContent(entry.GetEntryName()), entry.ShouldCheck(graph), (object data) => entry.Callback(data, graph), Event.current.mousePosition);
+                    }
+                    else
+                    {
+                        menu.AddDisabledItem(EditorGUIUtility.TrTextContent(entry.GetEntryName()));
+                    }
+                }
+            }
+            
+            [HarmonyTranspiler]
+            static IEnumerable<CodeInstruction> Transpiler(object __instance, IEnumerable<CodeInstruction> instructions)
+            {
+                var instructionList = instructions.ToList();
+                int genericMenuLocalIndex = -1;
+                for (var i = 0; i < instructionList.Count; i++)
+                {
+                    if (instructionList[i].opcode == OpCodes.Newobj && (ConstructorInfo)instructionList[i].operand == AccessTools.Constructor(typeof(GenericMenu), Type.EmptyTypes))
+                    {
+                        if (i + 1 < instructionList.Count && (instructionList[i + 1].opcode == OpCodes.Stloc_1 || 
+                                                              instructionList[i + 1].opcode == OpCodes.Stloc_2 ||
+                                                              instructionList[i + 1].opcode == OpCodes.Stloc_3 ||
+                                                              instructionList[i + 1].opcode == OpCodes.Stloc_S))
+                        {
+                            if (instructionList[i + 1].opcode == OpCodes.Stloc_1)
+                                genericMenuLocalIndex = 1;
+                            else if (instructionList[i + 1].opcode == OpCodes.Stloc_2)
+                                genericMenuLocalIndex = 2;
+                            else if (instructionList[i + 1].opcode == OpCodes.Stloc_3)
+                                genericMenuLocalIndex = 3;
+                            else if (instructionList[i + 1].opcode == OpCodes.Stloc_S) 
+                                genericMenuLocalIndex = ((LocalBuilder)instructionList[i + 1].operand).LocalIndex;
+                        }
+                    } 
+                    
+                    if (instructionList[i].opcode == OpCodes.Callvirt && (MethodInfo)instructionList[i].operand == AccessTools.Method(typeof(GenericMenu), "ShowAsContext"))
+                    {
+                        var newInstructions = new[]
+                        {
+                            new CodeInstruction(OpCodes.Ldarg_0),
+                            new CodeInstruction(OpCodes.Ldloc_S, genericMenuLocalIndex),
+                            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PatchStateMenu), "AddMenuItems")),
+                        }; 
+                        instructionList.InsertRange(i, newInstructions);
+                        break;
+                    }
+                }
+                return instructionList; 
+            }
+            
+             interface StateMenuEntry
+            {
+                string GetEntryName();
+                bool ShouldCheck(object data) => true;
+                bool ShouldEnable(object data) => true;
+                bool ShouldShow(object data) => true;
+                void Callback(object graph, object data);
+            }
+            
+            class MultipleTransitionEntry : StateMenuEntry
+            {
+                public string GetEntryName() => "Add Multiple Transitions";
+                public bool ShouldCheck(object data) => AnimatorWindowState.multipleState != null;
+                public bool ShouldEnable(object data) => true;
+                public bool ShouldShow(object data) => true;
+                public void Callback(object data, object stateNode)
+                {
+                    object graph =  AccessTools.Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.StateNode"),
+                        "get_graph").Invoke(stateNode, new object[0]);
+                    AnimatorStateMachine stateMachine = (AnimatorStateMachine)AccessTools
+                        .Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.Graph"),
+                            "get_activeStateMachine").Invoke(graph, new object[0]);
+
+                    if (AnimatorWindowState.multipleState == null)
+                    {
+                        AnimatorState state = Selection.activeObject as AnimatorState;
+                        if (state == null) return;
+                        AnimatorWindowState.multipleState = state;
+                        return;
+                    }
+                    
+                    AnimatorState[] selectedStates = Selection.objects.Where(x => x is AnimatorState).Cast<AnimatorState>().ToArray();
+                    foreach (var selectedState in selectedStates)
+                    {
+                        AnimatorWindowState.multipleState.AddTransition(selectedState);
+                    }
+                    AnimatorWindowState.multipleState = null;
+                    AccessTools.TypeByName("UnityEditor.Graphs.AnimatorControllerTool").GetMethod("RebuildGraph").Invoke(AccessTools.TypeByName("UnityEditor.Graphs.AnimatorControllerTool").GetField("tool").GetValue(null), new object[]{false});
+                }
+            }
+            
+            class RedirectMenuEntry : StateMenuEntry
+            {
+                public string GetEntryName() => "Redirect";
+                public bool ShouldShow(object data) => AnimatorWindowState.redirectTransition != null;
+                public void Callback(object data, object stateNode)
+                {
+                    object graph =  AccessTools.Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.StateNode"),
+                        "get_graph").Invoke(stateNode, new object[0]);
+                    AnimatorStateMachine stateMachine = (AnimatorStateMachine)AccessTools
+                        .Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.Graph"),
+                            "get_activeStateMachine").Invoke(graph, new object[0]);
+                    
+                    AnimatorState[] selectedStates = Selection.objects.Where(x => x is AnimatorState).Cast<AnimatorState>().ToArray();
+                    if (selectedStates.Length == 0) return;
+
+                    AnimatorStateTransition transition = AnimatorWindowState.redirectTransition as AnimatorStateTransition;
+                    
+
+                    foreach (var selectedState in selectedStates)
+                    {
+                        if (!stateMachine.anyStateTransitions.Contains(transition))
+                        {
+                            ChildAnimatorState source = stateMachine.states.FirstOrDefault(x => x.state.transitions.Contains(transition));
+                            if (source.state == null) continue;
+                            
+                            source.state.AddTransition(new AnimatorStateTransition()
+                            {
+                                canTransitionToSelf = transition.canTransitionToSelf,
+                                conditions = transition.conditions.Select(x => x).ToArray(),
+                                destinationState = selectedState,
+                                duration = transition.duration,
+                                exitTime = transition.exitTime,
+                                hasExitTime = transition.hasExitTime,
+                                hasFixedDuration = transition.hasFixedDuration,
+                                hideFlags = transition.hideFlags,
+                                interruptionSource = transition.interruptionSource,
+                            });
+                        }
+                        else
+                        {
+                            stateMachine.anyStateTransitions = stateMachine.anyStateTransitions.AddItem(new AnimatorStateTransition()
+                            {
+                                canTransitionToSelf = transition.canTransitionToSelf,
+                                conditions = transition.conditions.Select(x => x).ToArray(),
+                                duration = transition.duration,
+                                destinationState = selectedState,
+                                exitTime = transition.exitTime,
+                                hasExitTime = transition.hasExitTime,
+                                hasFixedDuration = transition.hasFixedDuration,
+                                hideFlags = transition.hideFlags,
+                                interruptionSource = transition.interruptionSource,
+                            }).ToArray();
+                            if (AssetDatabase.GetAssetPath(stateMachine) != "")
+                                AssetDatabase.AddObjectToAsset((UnityEngine.Object) stateMachine.anyStateTransitions.Last(), AssetDatabase.GetAssetPath(stateMachine));
+                        }
+                    }
+                    
+                    AnimatorWindowState.redirectTransition = null;
+                    AccessTools.TypeByName("UnityEditor.Graphs.AnimatorControllerTool").GetMethod("RebuildGraph").Invoke(AccessTools.TypeByName("UnityEditor.Graphs.AnimatorControllerTool").GetField("tool").GetValue(null), new object[]{false});
+                }
+            }
+            
+            class ReplicateMenuEntry : StateMenuEntry
+            {
+                public string GetEntryName() => "Replicate";
+                public bool ShouldShow(object data) => AnimatorWindowState.replicateTransition != null;
+
+                public void Callback(object data, object stateNode)
+                {
+                   
+                    object graph =  AccessTools.Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.StateNode"),
+                        "get_graph").Invoke(stateNode, new object[0]);
+                    AnimatorStateMachine stateMachine = (AnimatorStateMachine)AccessTools
+                        .Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.Graph"),
+                            "get_activeStateMachine").Invoke(graph, new object[0]);
+                    
+                    AnimatorState[] selectedStates = Selection.objects.Where(x => x is AnimatorState).Cast<AnimatorState>().ToArray();
+                    if (selectedStates.Length == 0) return;
+
+                    AnimatorStateTransition transition = AnimatorWindowState.replicateTransition as AnimatorStateTransition;
+                    
+                    ChildAnimatorState target = stateMachine.states.FirstOrDefault(x => x.state == transition.destinationState);
+                    if (target.state == null) return;
+                    foreach (var selectedState in selectedStates)
+                    {
+                        selectedState.AddTransition(new AnimatorStateTransition()
+                        {
+                            canTransitionToSelf = transition.canTransitionToSelf,
+                            conditions = transition.conditions.Select(x => x).ToArray(),
+                            destinationState = target.state,
+                            duration = transition.duration,
+                            exitTime = transition.exitTime,
+                            hasExitTime = transition.hasExitTime,
+                            hasFixedDuration = transition.hasFixedDuration,
+                            hideFlags = transition.hideFlags,
+                            interruptionSource = transition.interruptionSource,
+                        });
+                    }
+
+                    AnimatorWindowState.replicateTransition = null;
+                    AccessTools.TypeByName("UnityEditor.Graphs.AnimatorControllerTool").GetMethod("RebuildGraph").Invoke(AccessTools.TypeByName("UnityEditor.Graphs.AnimatorControllerTool").GetField("tool").GetValue(null), new object[]{false});
+                }
+            }
+        }
+
+        [HarmonyPatch]
+        [HarmonyPriority(Priority.Low)]
+        class PatchTransitionMenu
+        {
+            [HarmonyTargetMethod]
+            static MethodBase[] TargetMethods() => new[]
+            { 
+                AccessTools.Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.GraphGUI"), "HandleContextMenu"),
+            };
+
+            private static TransitionMenuEntry[] Entries = {
+                new ReverseMenuEntry(),
+                new RedirectMenuEntry(),
+                new ReplicateMenuEntry()
+            };
+            
+            static GenericMenu ReplaceMenu(GenericMenu menu, object graph)
+            {
+                if (!RATS.Prefs.ManipulateTransitionsMenuOption) return menu;
+                Vector2 current = Event.current.mousePosition;
+                UnityEngine.Object o = Selection.activeObject;
+                if (!(o is AnimatorTransitionBase transition)) return menu;
+
+                AnimatorStateMachine stateMachine = (AnimatorStateMachine)AccessTools
+                    .Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.GraphGUI"),
+                        "get_activeStateMachine").Invoke(graph, new object[0]);
+                
+                ChildAnimatorState source = stateMachine.states.FirstOrDefault(x => x.state.transitions.Contains(transition));
+                ChildAnimatorState target = stateMachine.states.FirstOrDefault(x => x.state == transition.destinationState);
+                
+                bool IsPointNearLine(Vector2 p, Vector2 a, Vector2 b, float d)
+                {
+                    Vector2 ab = b - a, ap = p - a;
+                    float t = Mathf.Clamp(Vector2.Dot(ap, ab) / ab.sqrMagnitude, 0, 1);
+                    return (p - (a + t * ab)).sqrMagnitude <= d * d;
+                }
+
+                current = current - new Vector2(100, 20); //Half of a state
+
+                bool isAnyState = stateMachine.anyStateTransitions.Contains(transition);
+                
+                if ((!isAnyState && source.state != null && target.state != null && IsPointNearLine(current, source.position, target.position, 20)) ||
+                    isAnyState && target.state != null && IsPointNearLine(current, stateMachine.anyStatePosition, target.position, 20))
+                {
+                    GenericMenu replaceMenu = new GenericMenu();
+                    foreach (TransitionMenuEntry menuEntry in Entries)
+                    {
+                        if (menuEntry.ShouldEnable(graph))
+                        {
+                            replaceMenu.AddItem(EditorGUIUtility.TrTextContent(menuEntry.GetEntryName()), menuEntry.ShouldCheck(graph), (object data) => menuEntry.Callback(data, graph), Event.current.mousePosition);
+                        }
+                        else
+                        {
+                            replaceMenu.AddDisabledItem(EditorGUIUtility.TrTextContent(menuEntry.GetEntryName()));
+                        }
+                    }
+                    return replaceMenu;
+                }
+                else
+                {
+                    return menu;
+                }
+            }
+            
+            [HarmonyTranspiler]
+            static IEnumerable<CodeInstruction> Transpiler(object __instance, IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+            {
+                var instructionList = instructions.ToList();
+                int genericMenuLocalIndex = -1;
+                for (var i = 0; i < instructionList.Count; i++)
+                {
+                    if (instructionList[i].opcode == OpCodes.Callvirt && (MethodInfo)instructionList[i].operand == AccessTools.Method(typeof(GenericMenu), "ShowAsContext"))
+                    {
+                        var newInstructions = new[]
+                        {
+                            new CodeInstruction(OpCodes.Ldarg_0),
+                            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PatchTransitionMenu), "ReplaceMenu")),
+                        }; 
+                        instructionList.InsertRange(i, newInstructions);
+                        break;
+                    }
+                }
+                return instructionList; 
+            }
+
+            interface TransitionMenuEntry
+            {
+                string GetEntryName();
+                bool ShouldCheck(object data) => false;
+                bool ShouldEnable(object data) => true;
+                void Callback(object graph, object data);
+            }
+            
+            class ReverseMenuEntry : TransitionMenuEntry
+            {
+                public string GetEntryName() => "Reverse";
+                public bool ShouldEnable(object data)
+                {
+                    if (!(Selection.activeObject is AnimatorTransitionBase transition)) return false;
+                    AnimatorStateMachine stateMachine = (AnimatorStateMachine)AccessTools
+                        .Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.GraphGUI"),
+                            "get_activeStateMachine").Invoke(data, new object[0]);
+                    return !stateMachine.anyStateTransitions.Contains(transition);
+                }
+                
+                public void Callback(object graph, object data)
+                {
+                    if (!(Selection.activeObject is AnimatorStateTransition transition)) return;
+                    AnimatorStateMachine stateMachine = (AnimatorStateMachine)AccessTools
+                        .Method(AccessTools.TypeByName("UnityEditor.Graphs.AnimationStateMachine.GraphGUI"),
+                            "get_activeStateMachine").Invoke(data, new object[0]);
+                
+                    ChildAnimatorState source = stateMachine.states.FirstOrDefault(x => x.state.transitions.Contains(transition));
+                    ChildAnimatorState target = stateMachine.states.FirstOrDefault(x => x.state == transition.destinationState);
+                    if (source.state == null || target.state == null) return;
+                    target.state.AddTransition(new AnimatorStateTransition()
+                    {
+                        canTransitionToSelf = transition.canTransitionToSelf,
+                        conditions = transition.conditions.Select(x => x).ToArray(),
+                        destinationState = source.state,
+                        duration = transition.duration,
+                        exitTime = transition.exitTime,
+                        hasExitTime = transition.hasExitTime,
+                        hasFixedDuration = transition.hasFixedDuration,
+                        hideFlags = transition.hideFlags,
+                        interruptionSource = transition.interruptionSource,
+                    });
+                    
+                    AccessTools.TypeByName("UnityEditor.Graphs.AnimatorControllerTool").GetMethod("RebuildGraph").Invoke(AccessTools.TypeByName("UnityEditor.Graphs.AnimatorControllerTool").GetField("tool").GetValue(null), new object[]{false});
+                }
+            }
+            
+            class RedirectMenuEntry : TransitionMenuEntry
+            {
+                public string GetEntryName() => "Redirect";
+                public bool ShouldCheck(object data) => AnimatorWindowState.redirectTransition != null;
+                public void Callback(object graph, object data)
+                {
+                    if (!(Selection.activeObject is AnimatorStateTransition transition)) return;
+
+                    if (AnimatorWindowState.redirectTransition == null)
+                    {
+                        AnimatorWindowState.redirectTransition = transition;
+                        AnimatorWindowState.replicateTransition = null;
+                    }
+                    else
+                    {
+                        AnimatorWindowState.redirectTransition = null;
+                    }
+                }
+            }
+            
+            class ReplicateMenuEntry : TransitionMenuEntry
+            {
+                public string GetEntryName() => "Replicate";
+                public bool ShouldCheck(object data) => AnimatorWindowState.replicateTransition != null;
+                public void Callback(object graph, object data)
+                {
+                    if (!(Selection.activeObject is AnimatorStateTransition transition)) return;
+
+                    if (AnimatorWindowState.replicateTransition == null)
+                    {
+                        AnimatorWindowState.replicateTransition = transition;
+                        AnimatorWindowState.redirectTransition = null;
+                    }
+                    else
+                    {
+                        AnimatorWindowState.replicateTransition = null;
+                    }
+                }
             }
         }
 

--- a/Editor/RATSPatchesProjectWindow.cs
+++ b/Editor/RATSPatchesProjectWindow.cs
@@ -174,6 +174,10 @@ namespace Razgriz.RATS
 
             if (controller == null) return;
 
+            if (!EditorUtility.DisplayDialog("Cleanup Controller",
+                    "This operation will remove all sub-assets not referenced in this Controller. This might remove assets that are still used externally. Make sure you have a backup of the Controller.",
+                    "Proceed", "Cancel")) return;
+            
             UnityEngine.Object[] subAssets = AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(controller)).Where(x => x != null).ToArray();
             
             List<UnityEngine.Object> relevantObjects = new List<UnityEngine.Object>();

--- a/Editor/RATSPatchesProjectWindow.cs
+++ b/Editor/RATSPatchesProjectWindow.cs
@@ -177,67 +177,168 @@ namespace Razgriz.RATS
             if (!EditorUtility.DisplayDialog("Cleanup Controller",
                     "This operation will remove all sub-assets not referenced in this Controller. This might remove assets that are still used externally. Make sure you have a backup of the Controller.",
                     "Proceed", "Cancel")) return;
-            
-            UnityEngine.Object[] subAssets = AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(controller)).Where(x => x != null).ToArray();
-            
-            List<UnityEngine.Object> relevantObjects = new List<UnityEngine.Object>();
-            relevantObjects.Add(controller);
-            controller.layers.ToList().ForEach(x => ProcessStateMachine(x.stateMachine, relevantObjects));
-            
-            void ProcessStateMachine(AnimatorStateMachine stateMachine, List<UnityEngine.Object> objects)
-            {
-                objects.Add(stateMachine);
-                foreach (var childAnimatorState in stateMachine.states)
-                {
-                    AnimatorState animatorState = childAnimatorState.state;
-                    objects.Add(animatorState);
-                    animatorState.transitions.ToList().ForEach(x => objects.Add(x));
-                    animatorState.behaviours.ToList().ForEach(x => objects.Add(x));
-				
-                    if (animatorState.motion is BlendTree tree)
-                    {
-                        Queue<BlendTree> trees = new Queue<BlendTree>(new [] {tree});
-                        while (trees.Count>0)
-                        {
-                            tree = trees.Dequeue();
-                            AssetDatabase.RemoveObjectFromAsset(tree);
-                            objects.Add(tree);
-                            tree.children.Where(x => x.motion is BlendTree).ToList().ForEach(x => trees.Enqueue((BlendTree)x.motion));
-                        }
-                    } else if (animatorState.motion is AnimationClip clip)
-                    {
-                        relevantObjects.Add(clip);
-                    }
-                }
-			
-                stateMachine.entryTransitions.ToList().ForEach(x => objects.Add(x));
-                stateMachine.anyStateTransitions.ToList().ForEach(x => objects.Add(x));
-                stateMachine.stateMachines.ToList().ForEach(x => ProcessStateMachine(x.stateMachine, relevantObjects));
-            }
-            
-            foreach (var subAsset in subAssets)
-            {
-                int totalRemoved = 0;
-                if (!relevantObjects.Contains(subAsset))
-                {
-                    AssetDatabase.RemoveObjectFromAsset(subAsset);
-                    Debug.Log("Removing: " + subAsset.name);
-                    totalRemoved++;
-                }
 
-                if (totalRemoved > 0)
-                {
-                    Debug.Log($"Removed {totalRemoved} Assets from Controller {controller.name}");
-                }
-            }
+            ScanController(controller);
         }
-
+            
         [MenuItem("Assets/Cleanup Controller", true)]
         private static bool ValidateCleanupController()
         {
             return Selection.objects.Any(x => x is AnimatorController) && Selection.objects.Length > 0;
         }
+        
+        // Code in the region below has been adapted from Dreadrith's Controller Cleaner, which has the following license
+        /*
+MIT License
+Copyright (c) 2024 Dreadrith
 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+         */
+        #region Dreadrith Controller Cleaner
+        static void ScanController(AnimatorController target)
+        {
+            var controller = target;
+            Type[] targetTypes = new [] {
+                typeof(AnimatorState), 
+                typeof(AnimatorStateTransition),
+                typeof(AnimatorStateMachine),
+                typeof(AnimatorTransition),
+                typeof(AnimatorTransitionBase),
+                typeof(StateMachineBehaviour),
+                typeof(BlendTree),
+            };
+
+            var allObjects = AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(controller)).Where(x => targetTypes.Contains(x.GetType())).ToArray();
+            var usedObjects = new List<UnityEngine.Object>();
+            for (int i = 0; i < controller.layers.Length; i++)
+                ScanMachine(controller.layers[i].stateMachine, true, usedObjects);
+            
+            var obsoleteObjects = allObjects.Except(usedObjects).ToArray();
+            bool shouldDestroy = obsoleteObjects.Length > 0;
+            if (shouldDestroy)
+            {
+                int destroyCount = 0;
+                foreach (var o in obsoleteObjects)
+                {
+                    if (!o) continue;
+                    Debug.Log($"Removed {o} from {controller}");
+                    destroyCount++;
+                    AssetDatabase.RemoveObjectFromAsset(o);
+                    UnityEngine.Object.DestroyImmediate(o);
+                }
+                Debug.Log($"Removed {destroyCount} assets from {controller}");
+            }
+
+            foreach (var l in controller.layers)
+                RemoveMissingTransitions(l.stateMachine);
+
+            if (shouldDestroy) ScanController(target);
+        }
+
+        static void RemoveMissingTransitions(AnimatorStateMachine m)
+        {
+            m.entryTransitions = m.entryTransitions.Where(o => o).ToArray();
+            m.anyStateTransitions = m.anyStateTransitions.Where(o => o).ToArray();
+            foreach (var cs in m.states)
+            {
+                cs.state.transitions = cs.state.transitions.Where(o => o).ToArray();
+                EditorUtility.SetDirty(cs.state);
+            }
+            foreach (var cssm in m.stateMachines)
+            {
+                m.SetStateMachineTransitions(cssm.stateMachine, m.GetStateMachineTransitions(cssm.stateMachine).Where(o => o).ToArray());
+                RemoveMissingTransitions(cssm.stateMachine);
+            }
+            EditorUtility.SetDirty(m);
+        }
+
+        static void ScanMachine(AnimatorStateMachine machine, bool isRootMachine, List<UnityEngine.Object> usedObjects)
+        {
+            usedObjects.Add(machine);
+            foreach (var b in machine.behaviours)
+                usedObjects.Add(b);
+            foreach (var cs in machine.states)
+            {
+                var s = cs.state;
+                usedObjects.Add(s);
+                AddTree(s.motion as BlendTree, usedObjects);
+                foreach (var t in s.transitions)
+                {
+                    if (!t) continue;
+                    if (t.destinationState || t.destinationStateMachine || t.isExit)
+                        usedObjects.Add(t);
+                }
+                foreach (var b in s.behaviours)
+                    usedObjects.Add(b);
+            }
+
+            foreach (var t in machine.entryTransitions)
+            {
+                if (!t) continue;
+                if (t.destinationState || t.destinationStateMachine || t.isExit)
+                    usedObjects.Add(t);
+            }
+
+            if (isRootMachine)
+            {
+                foreach (var t in machine.anyStateTransitions)
+                {
+                    if (!t) continue;
+                    if (t.destinationState || t.destinationStateMachine || t.isExit)
+                        usedObjects.Add(t);
+                }
+            }
+
+            for (int i = 0; i < machine.stateMachines.Length; i++)
+                ScanMachine(machine.stateMachines[i].stateMachine, false, usedObjects);
+            
+            FinalScanMachine(machine, usedObjects);
+            for (int i = 0; i < machine.stateMachines.Length; i++)
+                FinalScanMachine(machine.stateMachines[i].stateMachine, usedObjects);
+            
+        }
+
+        static void FinalScanMachine(AnimatorStateMachine machine, List<UnityEngine.Object> usedObjects)
+        {
+            foreach (var cssm in machine.stateMachines)
+            {
+                if (!cssm.stateMachine) continue;
+                foreach (var t in machine.GetStateMachineTransitions(cssm.stateMachine))
+                {
+                    if (!t) continue;
+                    if (t.destinationState || t.destinationStateMachine || t.isExit)
+                        usedObjects.Add(t);
+                }
+                FinalScanMachine(cssm.stateMachine, usedObjects);
+            }
+        }
+
+        
+        static void AddTree(BlendTree t, List<UnityEngine.Object> usedObjects)
+        {
+            if (!t) return;
+            usedObjects.Add(t);
+            foreach (var cm in t.children)
+                AddTree(cm.motion as BlendTree, usedObjects);
+        }
+        
+        #endregion //DREADRITH CONTROLLER CLEANER
     }
 }
 #endif

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Compatibility: Disable certain Animator window fixes/behaviors to avoid conflict
   - Icons for Blendtree/Loop Time
   - Warning icons For empty states/animations
 - Hold Alt to view all labels regardless of setting
+- Create Animator State by left control + double clicking
+- Create Transition by Left Control + double clicking on an Animator State
+- Make Multiple Transitions via State right-click menu
+- Reverse/Redirect/Replicate Transitions via right-click menu
+- Cleanup Controller Sub-Assets via Controller right-click menu
 - Animation Window: Show actual property name instead of "Display Name" in animation hierarchy
 - Animation Window: Show full path of keyframes
 - Animation Window: Reduce/Disable Indentation


### PR DESCRIPTION
Features Added:
- Create Animator State by left control + double clicking
- Create Transition by Left Control + double clicking on an Animator State
- Make Multiple Transitions via State right-click menu
- Reverse/Redirect/Replicate Transitions via right-click menu
- Cleanup Controller Sub-Assets via Controller right-click menu

Let me know if you want any changes made