### PR TITLE
Exclude git-related dirs from release zips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,12 @@ jobs:
           rsync -r --exclude="${{ env.packagePath }}" ./ "${{ env.packagePath }}"/
 
       - name: Create Zip
-        uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657
+        uses: thedoctor0/zip-release@78b32010bd8b7722906817a1f9e2a7190a182d0c
         with:
           type: "zip"
           directory: "${{ env.packagePath }}/"
           filename: "../../${{env.zipFile}}" # make the zip file two directories up, since we start two directories in above
+          exclusions: '/.git* .git*' # Exclude build-time .git dir, .github dir, and .gitignore, among others at the root
 
       - run: find "${{env.packagePath}}" -name \*.meta >> metaList
 


### PR DESCRIPTION
This updates the zip-release action, and adds both directories and files that begin with ".git" at the root of the repo to the exclusions list.

While this may work on the old version of zip-release, the newest version includes explicit documentation about directories starting with a . at the root, such as git - might as well use that one.

This needs to still be tested, but it should work. I have not worked with runners enough to be sure, but it seems right.
It seems internally it uses tar and 7z depending on platform, and builds args based on that - I do not know enough about the exclusion behavior of both to know that this works for sure, but either way, it's a start.