### PR TITLE
MACS Compatibility

### DIFF
--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -55,6 +55,13 @@ namespace Razgriz.RATS
     public class RATSPreferences
     {
         public bool DisableAnimatorGraphFixes = false;
+        public bool MACSCompatibleLayerIcons = false;
+        public bool InfoLabelInAnimator = true;
+        public bool ShowEmptyLayerIcon = true;
+        public Color EmptyLayerIconColor = new Color(1.0f, 0.5f, 0f);
+        public bool ShowWDLayerIcon = true;
+        public Color WDLayerIconColor = new Color(1.0f, 1.0f, 1.0f);
+        public bool ShowMixedWDIcon = true;
         public bool StateMotionLabels = true;
         public bool StateBlendtreeLabels = true;
         public bool StateAnimIsEmptyLabel = true;
@@ -69,6 +76,7 @@ namespace Razgriz.RATS
         public bool StateExtraLabelsBehavior = true;
         public bool StateExtraLabelsMotionTime = true;
         public bool StateExtraLabelsSpeed = true;
+        public bool DebugLabelsOnAlt = true;
         public bool GraphGridOverride = true;
         public float GraphGridDivisorMinor = 1.0f;
         public float GraphGridScalingMajor = 0.0f;
@@ -231,6 +239,7 @@ namespace Razgriz.RATS
                 if(sectionExpandedStyling)
                 {
                     EditorGUI.indentLevel += 1;
+                    DrawAnimatorOptions();
                     DrawGraphLabelsOptions();
                     DrawGridStyleOptions();
                     DrawNodeStyleOptions();
@@ -314,6 +323,41 @@ namespace Razgriz.RATS
             }
         }
 
+        private static void DrawAnimatorOptions()
+        {
+            using (new GUILayout.VerticalScope())
+            {
+                DrawUILine(lightUILineColor);
+                SectionLabel(new GUIContent("  Animator Tweaks", EditorGUIUtility.IconContent("d_Animator Icon").image));
+                EditorGUI.indentLevel += optionsIndentStep;
+
+                using (new GUILayout.HorizontalScope())
+                {
+                    ToggleButton(ref RATS.Prefs.MACSCompatibleLayerIcons, "MACS Compatible Layer Icons", "Makes layer icons not overlap with MACS");
+                    ToggleButton(ref RATS.Prefs.InfoLabelInAnimator, "Animator information", "Shows information about the animator at the bottom");
+                }
+
+                using (new GUILayout.HorizontalScope())
+                {
+                    ToggleButton(ref RATS.Prefs.ShowEmptyLayerIcon, "Show Empty Layer Icon", "Shows \"E\" when a layer only has empty animations");
+                    RATS.Prefs.EmptyLayerIconColor = EditorGUILayout.ColorField("Empty Layer Icon", RATS.Prefs.EmptyLayerIconColor);
+                }
+
+                using (new GUILayout.HorizontalScope())
+                {
+                    ToggleButton(ref RATS.Prefs.ShowWDLayerIcon, "Show Layer WD State", "Shows \"WD\" if a layer has Write Defaults turned on. Shows nothing if Write Defaults is off.");
+                    RATS.Prefs.WDLayerIconColor = EditorGUILayout.ColorField("WD Layer Icon", RATS.Prefs.WDLayerIconColor);
+                }
+
+                using (new GUILayout.HorizontalScope())
+                {
+                    ToggleButton(ref RATS.Prefs.ShowMixedWDIcon, "Show Mixed WD Layer Icon", "Shows a warning icon if a layer has mixed Write Defaults.");
+                }
+
+                EditorGUI.indentLevel -= optionsIndentStep;
+            }
+        }
+
         private static void DrawGraphLabelsOptions()
         {
             // Graph Labels
@@ -366,8 +410,9 @@ namespace Razgriz.RATS
 
                 using (new GUILayout.HorizontalScope())
                 {
-                    EditorGUILayout.LabelField("Tip: Hold ALT to see all labels at any time", new GUIStyle("miniLabel"));
+                    ToggleButton(ref RATS.Prefs.DebugLabelsOnAlt, "Hold ALT to see all labels at any time", "Hold ALT to see all labels at any time");
                 }
+
                 EditorGUI.indentLevel -= optionsIndentStep;
             }
         }

--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -333,13 +333,13 @@ namespace Razgriz.RATS
 
                 using (new GUILayout.HorizontalScope())
                 {
-                    ToggleButton(ref RATS.Prefs.MACSCompatibleLayerIcons, "MACS Compatible Layer Icons", "Makes layer icons not overlap with MACS");
+                    ToggleButton(ref RATS.Prefs.MACSCompatibleLayerIcons, "MACS Compatible Layer Icons", "Makes layer icons not overlap with MACS layer indexes");
                     ToggleButton(ref RATS.Prefs.InfoLabelInAnimator, "Animator information", "Shows information about the animator at the bottom");
                 }
 
                 using (new GUILayout.HorizontalScope())
                 {
-                    ToggleButton(ref RATS.Prefs.ShowEmptyLayerIcon, "Show Empty Layer Icon", "Shows \"E\" when a layer only has empty animations");
+                    ToggleButton(ref RATS.Prefs.ShowEmptyLayerIcon, "Show Empty Layer Icon", "Shows \"E\" when a layer doesn't have states.");
                     RATS.Prefs.EmptyLayerIconColor = EditorGUILayout.ColorField("Empty Layer Icon", RATS.Prefs.EmptyLayerIconColor);
                 }
 

--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -55,13 +55,6 @@ namespace Razgriz.RATS
     public class RATSPreferences
     {
         public bool DisableAnimatorGraphFixes = false;
-        public bool MACSCompatibleLayerIcons = false;
-        public bool InfoLabelInAnimator = true;
-        public bool ShowEmptyLayerIcon = true;
-        public Color EmptyLayerIconColor = new Color(1.0f, 0.5f, 0f);
-        public bool ShowWDLayerIcon = true;
-        public Color WDLayerIconColor = new Color(1.0f, 1.0f, 1.0f);
-        public bool ShowMixedWDIcon = true;
         public bool StateMotionLabels = true;
         public bool StateBlendtreeLabels = true;
         public bool StateAnimIsEmptyLabel = true;
@@ -76,7 +69,6 @@ namespace Razgriz.RATS
         public bool StateExtraLabelsBehavior = true;
         public bool StateExtraLabelsMotionTime = true;
         public bool StateExtraLabelsSpeed = true;
-        public bool DebugLabelsOnAlt = true;
         public bool GraphGridOverride = true;
         public float GraphGridDivisorMinor = 1.0f;
         public float GraphGridScalingMajor = 0.0f;
@@ -121,6 +113,12 @@ namespace Razgriz.RATS
         public bool ProjectWindowFolderChildren = true;
         public Color ProjectWindowLabelTextColor = new Color(1.0f, 1.0f, 1.0f, 0.3f);
         public TextAnchor ProjectWindowLabelAlignment = TextAnchor.MiddleRight;
+        public bool DebugLabelsOnAlt = true;
+        public bool MACSCompatibleLayerIcons = false;
+        public bool InfoLabelInAnimator = true;
+        public bool ShowEmptyLayerIcon = true;
+        public Color EmptyLayerIconColor = new Color(1.0f, 0.5f, 0f);
+        public Color WDLayerIconColor = new Color(1.0f, 1.0f, 1.0f);
     }
 
     public static class RATSPreferenceHandler
@@ -333,7 +331,6 @@ namespace Razgriz.RATS
 
                 using (new GUILayout.HorizontalScope())
                 {
-                    ToggleButton(ref RATS.Prefs.MACSCompatibleLayerIcons, "MACS Compatible Layer Icons", "Makes layer icons not overlap with MACS layer indexes");
                     ToggleButton(ref RATS.Prefs.InfoLabelInAnimator, "Animator information", "Shows information about the animator at the bottom");
                 }
 
@@ -345,13 +342,15 @@ namespace Razgriz.RATS
 
                 using (new GUILayout.HorizontalScope())
                 {
-                    ToggleButton(ref RATS.Prefs.ShowWDLayerIcon, "Show Layer WD State", "Shows \"WD\" if a layer has Write Defaults turned on. Shows nothing if Write Defaults is off.");
+                    ToggleButton(ref RATS.Prefs.LayerListShowWD, "Show Layer WD State", "Shows \"WD\" if a layer has at least one state with Write Defaults turned on.\n" +
+                                                                 "Shows nothing if Write Defaults is off for all states on the layer.");
                     RATS.Prefs.WDLayerIconColor = EditorGUILayout.ColorField("WD Layer Icon", RATS.Prefs.WDLayerIconColor);
                 }
 
                 using (new GUILayout.HorizontalScope())
                 {
-                    ToggleButton(ref RATS.Prefs.ShowMixedWDIcon, "Show Mixed WD Layer Icon", "Shows a warning icon if a layer has mixed Write Defaults.");
+                    ToggleButton(ref RATS.Prefs.LayerListShowMixedWD, "Show Mixed WD Layer Icon", "Shows a warning icon if a layer has mixed Write Defaults.");
+                    ToggleButton(ref RATS.Prefs.MACSCompatibleLayerIcons, "MACS Compatible Layer Icons", "Makes layer icons not overlap with MACS layer indexes");
                 }
 
                 EditorGUI.indentLevel -= optionsIndentStep;

--- a/Editor/RATSGUI.cs
+++ b/Editor/RATSGUI.cs
@@ -114,7 +114,7 @@ namespace Razgriz.RATS
         public Color ProjectWindowLabelTextColor = new Color(1.0f, 1.0f, 1.0f, 0.3f);
         public TextAnchor ProjectWindowLabelAlignment = TextAnchor.MiddleRight;
         public bool DebugLabelsOnAlt = true;
-        public bool MACSCompatibleLayerIcons = false;
+        public bool MACSCompatibility = false;
         public bool InfoLabelInAnimator = true;
         public bool ShowEmptyLayerIcon = true;
         public Color EmptyLayerIconColor = new Color(1.0f, 0.5f, 0f);
@@ -350,7 +350,7 @@ namespace Razgriz.RATS
                 using (new GUILayout.HorizontalScope())
                 {
                     ToggleButton(ref RATS.Prefs.LayerListShowMixedWD, "Show Mixed WD Layer Icon", "Shows a warning icon if a layer has mixed Write Defaults.");
-                    ToggleButton(ref RATS.Prefs.MACSCompatibleLayerIcons, "MACS Compatible Layer Icons", "Makes layer icons not overlap with MACS layer indexes");
+                    ToggleButton(ref RATS.Prefs.MACSCompatibility, "MACS Compatibility", "Makes layer icons not overlap with MACS layer indexes, and disables layer creation auto scroll and parameter creation auto scroll patches in RATS. Use these in MACS.");
                 }
 
                 EditorGUI.indentLevel -= optionsIndentStep;

--- a/Editor/RATSPatchesAnimatorWindow.cs
+++ b/Editor/RATSPatchesAnimatorWindow.cs
@@ -328,7 +328,14 @@ namespace Razgriz.RATS
 
             static PatchLayerWriteDefaultsIndicator()
             {
-                LayerWDStyle.fontSize = 9;
+                if (RATS.Prefs.MACSCompatibleLayerIcons)
+                {
+                    LayerWDStyle.fontSize = 8;
+                }
+                else
+                {
+                    LayerWDStyle.fontSize = 9;
+                }
             }
 
             // TODO: Not sure if this should be done for every layer but gonna stick with it for now
@@ -353,27 +360,51 @@ namespace Razgriz.RATS
                 layerLabelRect.x -= 19;
                 layerLabelRect.y += 15;
 
-                if(layerStateMachine.states.Length == 0 && layerStateMachine.stateMachines.Length == 0)
+                if (RATS.Prefs.MACSCompatibleLayerIcons)
                 {
-                    EditorGUI.LabelField(layerLabelRect, "  E", LayerWDStyle);
-                    return; 
+                    layerLabelRect.y -= 6;
+                    layerLabelRect.x += 2;
+                }
+
+                if (RATS.Prefs.ShowEmptyLayerIcon)
+                {
+                    if (layerStateMachine.states.Length == 0 && layerStateMachine.stateMachines.Length == 0)
+                    {
+                        LayerWDStyle.normal.textColor = RATS.Prefs.EmptyLayerIconColor;
+                        EditorGUI.LabelField(layerLabelRect, "  E", LayerWDStyle);
+                        return;
+                    }
                 }
 
                 int layerWDOnCount = 0;
                 int layerWDOffCount = 0;
 
                 RATS.RecursivelyDetermineStateMachineWDStatus(layerStateMachine, ref layerWDOnCount, ref layerWDOffCount);
+                LayerWDStyle.normal.textColor = RATS.Prefs.WDLayerIconColor;
 
-                if(Prefs.LayerListShowMixedWD && layerWDOnCount > 0 && layerWDOffCount > 0)
+                if (Prefs.LayerListShowMixedWD && layerWDOnCount > 0 && layerWDOffCount > 0)
                 {
-                    layerLabelRect.width = 16;
-                    layerLabelRect.height = 16;
-                    layerLabelRect.x += 2;
-                    EditorGUI.LabelField(layerLabelRect, new GUIContent(EditorGUIUtility.IconContent("Error").image, "Layer has mixed Write Defaults settings"));
+                    if (RATS.Prefs.ShowMixedWDIcon)
+                    {
+                        layerLabelRect.width = 16;
+                        layerLabelRect.height = 16;
+                        layerLabelRect.x += 2;
+
+                        if (RATS.Prefs.MACSCompatibleLayerIcons)
+                        {
+                            layerLabelRect.x -= 3;
+                            layerLabelRect.y -= 5;
+                        }
+
+                        EditorGUI.LabelField(layerLabelRect, new GUIContent(EditorGUIUtility.IconContent("Error").image, "Layer has mixed Write Defaults settings"));
+                    }
                 }
                 else if(Prefs.LayerListShowWD)
                 {
-                    EditorGUI.LabelField(layerLabelRect, (layerWDOnCount > 0 ? "WD" : ""), LayerWDStyle);
+                    if (RATS.Prefs.ShowWDLayerIcon)
+                    {
+                        EditorGUI.LabelField(layerLabelRect, (layerWDOnCount > 0 ? "WD" : ""), LayerWDStyle);
+                    }
                 }
             }
         }
@@ -1103,47 +1134,50 @@ namespace Razgriz.RATS
 
                     string compatibilityString = "";
 
-                    #if RATS_NO_ANIMATOR
+#if RATS_NO_ANIMATOR
                     compatibilityString = " (Compatibility)";
-                    #endif
-                    GUIContent RATSLabel = new GUIContent($"  RATS{compatibilityString}  |  WD: {WDStatus}   ", (Texture)RATSGUI.GetRATSIcon());
-                    float RATSLabelWidth = (buttonStyle).CalcSize(RATSLabel).x;
-                    float controllerLabelWidth = (EditorStyles.miniLabel).CalcSize(new GUIContent(AssetDatabase.GetAssetPath(ctrl))).x;
-                    float controllerIconWidth = 16;
-                    Rect pingControllerRect = new Rect(nameRect.x + nameRect.width - controllerLabelWidth - controllerIconWidth, nameRect.y, controllerLabelWidth + controllerIconWidth, nameRect.height);
-                    Rect RATSLabelrect = new Rect(nameRect.x + nameRect.width - pingControllerRect.width - RATSLabelWidth, nameRect.y, RATSLabelWidth, nameRect.height);
-
-                    GUILayout.BeginArea(RATSLabelrect);
-                    EditorGUILayout.LabelField(RATSLabel, buttonStyle);
-                    GUILayout.EndArea();
-                    EditorGUIUtility.AddCursorRect(RATSLabelrect, MouseCursor.Link); // Show hand cursor on hover
-
-                    GUILayout.BeginArea(pingControllerRect);
-                    EditorGUILayout.LabelField(new GUIContent((Texture)EditorGUIUtility.IconContent("AnimatorController On Icon").image), EditorStyles.miniLabel, GUILayout.Width(controllerIconWidth));
-                    GUILayout.EndArea();
-                    EditorGUIUtility.AddCursorRect(pingControllerRect, MouseCursor.Link);
-
-                    Event current = Event.current;
-                    if ((current.type == EventType.MouseDown) && (current.button == 0))
+#endif
+                    if (RATS.Prefs.InfoLabelInAnimator)
                     {
-                        if(RATSLabelrect.Contains(current.mousePosition))
+                        GUIContent RATSLabel = new GUIContent($"  RATS{compatibilityString}  |  WD: {WDStatus}   ", (Texture)RATSGUI.GetRATSIcon());
+                        float RATSLabelWidth = (buttonStyle).CalcSize(RATSLabel).x;
+                        float controllerLabelWidth = (EditorStyles.miniLabel).CalcSize(new GUIContent(AssetDatabase.GetAssetPath(ctrl))).x;
+                        float controllerIconWidth = 16;
+                        Rect pingControllerRect = new Rect(nameRect.x + nameRect.width - controllerLabelWidth - controllerIconWidth, nameRect.y, controllerLabelWidth + controllerIconWidth, nameRect.height);
+                        Rect RATSLabelrect = new Rect(nameRect.x + nameRect.width - pingControllerRect.width - RATSLabelWidth, nameRect.y, RATSLabelWidth, nameRect.height);
+
+                        GUILayout.BeginArea(RATSLabelrect);
+                        EditorGUILayout.LabelField(RATSLabel, buttonStyle);
+                        GUILayout.EndArea();
+                        EditorGUIUtility.AddCursorRect(RATSLabelrect, MouseCursor.Link); // Show hand cursor on hover
+
+                        GUILayout.BeginArea(pingControllerRect);
+                        EditorGUILayout.LabelField(new GUIContent((Texture)EditorGUIUtility.IconContent("AnimatorController On Icon").image), EditorStyles.miniLabel, GUILayout.Width(controllerIconWidth));
+                        GUILayout.EndArea();
+                        EditorGUIUtility.AddCursorRect(pingControllerRect, MouseCursor.Link);
+
+                        Event current = Event.current;
+                        if ((current.type == EventType.MouseDown) && (current.button == 0))
                         {
-                            current.Use();
-                            GenericMenu menu = new GenericMenu();
-                            menu.AddItem(EditorGUIUtility.TrTextContent("RATS Options", null, (Texture) null), false,
-                                new GenericMenu.MenuFunction2((object obj) => RATSGUI.ShowWindow()), null);
-                            menu.AddItem(EditorGUIUtility.TrTextContent("Refresh Textures", null, (Texture) null), false,
-                                new GenericMenu.MenuFunction2((object obj) => RATS.HandleTextures()), null);
-                            menu.ShowAsContext();
+                            if (RATSLabelrect.Contains(current.mousePosition))
+                            {
+                                current.Use();
+                                GenericMenu menu = new GenericMenu();
+                                menu.AddItem(EditorGUIUtility.TrTextContent("RATS Options", null, (Texture)null), false,
+                                    new GenericMenu.MenuFunction2((object obj) => RATSGUI.ShowWindow()), null);
+                                menu.AddItem(EditorGUIUtility.TrTextContent("Refresh Textures", null, (Texture)null), false,
+                                    new GenericMenu.MenuFunction2((object obj) => RATS.HandleTextures()), null);
+                                menu.ShowAsContext();
+                            }
+                            else if (pingControllerRect.Contains(current.mousePosition))
+                            {
+                                current.Use();
+                                EditorGUIUtility.PingObject(ctrl);
+                                // Adhere to the 'select only on double click' convention
+                                if (current.clickCount == 2) Selection.activeObject = ctrl;
+                            }
                         }
-                        else if(pingControllerRect.Contains(current.mousePosition))
-                        {
-                            current.Use();
-                            EditorGUIUtility.PingObject(ctrl);
-                            // Adhere to the 'select only on double click' convention
-                            if (current.clickCount == 2) Selection.activeObject = ctrl;
-                        }
-                    } 
+                    }
                     
                 }
             }
@@ -1370,6 +1404,9 @@ namespace Razgriz.RATS
                 Rect stateRect = GUILayoutUtility.GetLastRect();
 
                 bool debugShowLabels = Event.current.alt;
+
+                if (RATS.Prefs.DebugLabelsOnAlt == false)
+                    debugShowLabels = false;
 
                 // Tags in corner, similar to what layer editor does
                 if ((hasMotion || hasStateMachine))

--- a/Editor/RATSPatchesAnimatorWindow.cs
+++ b/Editor/RATSPatchesAnimatorWindow.cs
@@ -384,7 +384,7 @@ namespace Razgriz.RATS
 
                 if (Prefs.LayerListShowMixedWD && layerWDOnCount > 0 && layerWDOffCount > 0)
                 {
-                    if (RATS.Prefs.ShowMixedWDIcon)
+                    if (RATS.Prefs.LayerListShowMixedWD)
                     {
                         layerLabelRect.width = 16;
                         layerLabelRect.height = 16;
@@ -399,12 +399,9 @@ namespace Razgriz.RATS
                         EditorGUI.LabelField(layerLabelRect, new GUIContent(EditorGUIUtility.IconContent("Error").image, "Layer has mixed Write Defaults settings"));
                     }
                 }
-                else if(Prefs.LayerListShowWD)
+                else if (RATS.Prefs.LayerListShowWD)
                 {
-                    if (RATS.Prefs.ShowWDLayerIcon)
-                    {
-                        EditorGUI.LabelField(layerLabelRect, (layerWDOnCount > 0 ? "WD" : ""), LayerWDStyle);
-                    }
+                    EditorGUI.LabelField(layerLabelRect, (layerWDOnCount > 0 ? "WD" : ""), LayerWDStyle);
                 }
             }
         }

--- a/Editor/RATSPatchesAnimatorWindow.cs
+++ b/Editor/RATSPatchesAnimatorWindow.cs
@@ -346,7 +346,7 @@ namespace Razgriz.RATS
             static void Prefix(object __instance, Rect rect, int index, bool selected, bool focused)
             {
                 // Don't show if not configured, or if playing (prevents indicator from getting pushed off screen)
-                if(!(Prefs.LayerListShowWD || Prefs.LayerListShowMixedWD) || EditorApplication.isPlaying)
+                if (!(Prefs.LayerListShowWD || Prefs.LayerListShowMixedWD || Prefs.ShowEmptyLayerIcon) || EditorApplication.isPlaying)
                     return;
 
                 AnimatorController controller = (AnimatorController)AnimatorControllerField.GetValue(IAnimatorControllerEditorField.GetValue(__instance));

--- a/Editor/RATSPatchesAnimatorWindow.cs
+++ b/Editor/RATSPatchesAnimatorWindow.cs
@@ -74,6 +74,8 @@ namespace Razgriz.RATS
             [HarmonyPostfix]
             static void Postfix(object __instance)
             {
+                if (RATS.Prefs.MACSCompatibility) return;
+
                 Vector2 scrollpos = (Vector2)LayerScrollField.GetValue(__instance);
                 if (scrollpos.y == 0)
                     LayerScrollField.SetValue(__instance, AnimatorWindowState.layerScrollCache);
@@ -92,6 +94,8 @@ namespace Razgriz.RATS
             [HarmonyPostfix]
             public static void Postfix(object __instance, object value)
             {
+                if (RATS.Prefs.MACSCompatibility) return;
+
                 Traverse.Create(__instance).Field("m_ScrollPosition").SetValue(new Vector2(0, 9001));
             }
         }
@@ -328,7 +332,7 @@ namespace Razgriz.RATS
 
             static PatchLayerWriteDefaultsIndicator()
             {
-                if (RATS.Prefs.MACSCompatibleLayerIcons)
+                if (RATS.Prefs.MACSCompatibility)
                 {
                     LayerWDStyle.fontSize = 8;
                 }
@@ -360,7 +364,7 @@ namespace Razgriz.RATS
                 layerLabelRect.x -= 19;
                 layerLabelRect.y += 15;
 
-                if (RATS.Prefs.MACSCompatibleLayerIcons)
+                if (RATS.Prefs.MACSCompatibility)
                 {
                     layerLabelRect.y -= 6;
                     layerLabelRect.x += 2;
@@ -390,7 +394,7 @@ namespace Razgriz.RATS
                         layerLabelRect.height = 16;
                         layerLabelRect.x += 2;
 
-                        if (RATS.Prefs.MACSCompatibleLayerIcons)
+                        if (RATS.Prefs.MACSCompatibility)
                         {
                             layerLabelRect.x -= 3;
                             layerLabelRect.y -= 5;


### PR DESCRIPTION
New settings group: Animator Tweaks
- MACS Compatible Layer Icons (New Feature)
- Show Empty Layer Icon (Now toggleable)
- Show Layer WD State (Now toggleable)
- Show Mixed WD Layer Icon (Now toggleable)
- Animator Info (Now toggleable)
- Empty Layer Icon Color (New Feature)
- WD Layer Icon Color (New Feature)

Animator Graph Labels Settings Group
- Hold ALT to see all labels at any time (Now toggleable)