### PR TITLE
No state machine fix

### DIFF
--- a/Editor/RATSPatchesAnimatorWindow.cs
+++ b/Editor/RATSPatchesAnimatorWindow.cs
@@ -376,6 +376,9 @@ namespace Razgriz.RATS
 
                 var layerStateMachine = controller.layers[index].stateMachine;
 
+                if (layerStateMachine == null)
+                    return;
+
                 // Adjust position to be off to the left
                 Rect layerLabelRect = rect;
                 layerLabelRect.width = 18;


### PR DESCRIPTION
Fix for the Animator window breaking, because a layer didn't have a State Machine